### PR TITLE
removed codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  token: 144fb211-28fa-4df0-a15a-81e43e6d7763


### PR DESCRIPTION
We don't have unit testing for this yet, so codecov won't work. 

Will add heroku deployment + add to slack soon, will need botkit for it.